### PR TITLE
Add option to set a WebSocket factory (e.g. for node support)

### DIFF
--- a/src/jsonrpc-websocket.ts
+++ b/src/jsonrpc-websocket.ts
@@ -56,9 +56,11 @@ export class JsonRpcWebsocket {
     return this.createWebsocket();
   }
 
-  public close(): Promise<CloseEvent> {
+  public close(): Promise<CloseEvent | boolean> {
     if (this.websocket === undefined) {
-      return Promise.resolve(new CloseEvent('No websocket was opened', { wasClean: false, code: 1005 }));
+      return Promise.resolve(
+        globalThis.CloseEvent ? new CloseEvent('No websocket was opened', { wasClean: false, code: 1005 }) : true,
+      );
     }
 
     this.websocket.close(1000); // 1000 = normal closure

--- a/src/jsonrpc-websocket.ts
+++ b/src/jsonrpc-websocket.ts
@@ -187,7 +187,7 @@ export class JsonRpcWebsocket {
       jsonrpc: this.jsonRpcVersion,
       error: error,
       id: id,
-      result: result
+      result: result,
     };
 
     try {
@@ -259,7 +259,7 @@ export class JsonRpcWebsocket {
       if (request.params instanceof Array) {
         if (method.length !== request.params.length) {
           throw new Error(
-            `Invalid parameters. Method '${request.method}' expects ${method.length} parameters, but got ${request.params.length}`
+            `Invalid parameters. Method '${request.method}' expects ${method.length} parameters, but got ${request.params.length}`,
           );
         }
         requestParams = request.params;
@@ -268,15 +268,19 @@ export class JsonRpcWebsocket {
 
         if (method.length !== Object.keys(request.params).length) {
           throw new Error(
-            `Invalid parameters. Method '${request.method}' expects parameters [${parameterNames}], but got [${Object.keys(request.params)}]`
+            `Invalid parameters. Method '${
+              request.method
+            }' expects parameters [${parameterNames}], but got [${Object.keys(request.params)}]`,
           );
         }
 
-        parameterNames.forEach(paramName => {
+        parameterNames.forEach((paramName) => {
           const paramValue = request.params[paramName];
           if (paramValue === undefined) {
             throw new Error(
-              `Invalid parameters. Method '${request.method}' expects parameters [${parameterNames}], but got [${Object.keys(request.params)}]`
+              `Invalid parameters. Method '${
+                request.method
+              }' expects parameters [${parameterNames}], but got [${Object.keys(request.params)}]`,
             );
           }
           requestParams.push(paramValue);
@@ -298,7 +302,7 @@ export class JsonRpcWebsocket {
       return;
     }
 
-    self.clearTimeout(activeRequest.timeout);
+    clearTimeout(activeRequest.timeout);
 
     if (this.hasProperty(response, 'result') && this.hasProperty(response, 'error')) {
       const errorResponse: JsonRpcResponse = {
@@ -339,7 +343,7 @@ export class JsonRpcWebsocket {
   }
 
   private setupRequestTimeout(requestId: number): number {
-    return self.setTimeout(() => {
+    return setTimeout(() => {
       const activeRequest = this.pendingRequests[requestId];
 
       // istanbul ignore if
@@ -359,7 +363,7 @@ export class JsonRpcWebsocket {
       delete this.pendingRequests[requestId];
 
       activeRequest.response.reject(response);
-    }, this.requestTimeoutMs);
+    }, this.requestTimeoutMs) as unknown as number;
   }
 
   private callOnError(error: JsonRpcError): void {

--- a/src/jsonrpc-websocket.ts
+++ b/src/jsonrpc-websocket.ts
@@ -248,9 +248,15 @@ export class JsonRpcWebsocket {
       return;
     }
 
-    const result = method(...requestParams);
-    if (request.id) {
-      this.respondOk(request.id, result);
+    try {
+      const result = method(...requestParams);
+      if (request.id) {
+        this.respondOk(request.id, result);
+      }
+    } catch (e) {
+      if (request.id) {
+        this.respondError(request.id, e);
+      }
     }
   }
 


### PR DESCRIPTION
Hi, I wanted to use this library with nodejs, and felt the easiest way without adding any deps would be to add a method to set a websocket factory, which is used instead of the `new WebSocket` global if provided.

Usage for a module that can be used in either browser or node could then be:

```typescript

import { isBrowser } from 'browser-or-node'
import { JsonRpcWebsocket, JsonRpcError } from 'jsonrpc-client-websocket'

if (!isBrowser) {
  JsonRpcWebsocket.setWebSocketFactory((url: string) => {
    const ws = require('websocket').client
    return new ws(url)
  })
}
```

Pretty straightforward but realise implementation is down to personal taste - let me know if you like this approach or if you favour something different.